### PR TITLE
Only compute BitArray bit index and mask once

### DIFF
--- a/src/main/java/com/github/jparkie/pdd/BitArray.java
+++ b/src/main/java/com/github/jparkie/pdd/BitArray.java
@@ -40,13 +40,13 @@ public final class BitArray {
 
     public boolean get(long index) {
         final int arrayIndex = (int)(index >>> 6);
-        final long bitMask = 1L << (index & 0x3F);
+        final long bitMask = 1L << index;
         return (data[arrayIndex] & bitMask) != 0;
     }
 
     public boolean set(long index) {
         final int arrayIndex = (int)(index >>> 6);
-        final long bitMask = 1L << (index & 0x3F);
+        final long bitMask = 1L << index;
         if ((data[arrayIndex] & bitMask) == 0) {
             data[arrayIndex] |= bitMask;
             bitCount++;
@@ -57,7 +57,7 @@ public final class BitArray {
 
     public boolean clear(long index) {
         final int arrayIndex = (int)(index >>> 6);
-        final long bitMask = 1L << (index & 0x3F);
+        final long bitMask = 1L << index;
         if ((data[arrayIndex] & bitMask) != 0) {
             data[arrayIndex] &= ~bitMask;
             bitCount--;

--- a/src/main/java/com/github/jparkie/pdd/BitArray.java
+++ b/src/main/java/com/github/jparkie/pdd/BitArray.java
@@ -38,13 +38,25 @@ public final class BitArray {
         return (int) numWords;
     }
 
+    private final class indexAndMask {
+        public final int index;
+        public final long mask;
+
+        public indexAndMask(long index) {
+            this.index = (int)(index >>> 6);
+            this.mask = 1L << (index & 0x3F);
+        }
+    }
+
     public boolean get(long index) {
-        return (data[(int) (index >>> 6)] & (1L << index)) != 0;
+        final indexAndMask iam = new indexAndMask(index);
+        return (data[iam.index] & iam.mask) != 0;
     }
 
     public boolean set(long index) {
-        if (!get(index)) {
-            data[(int) (index >>> 6)] |= (1L << index);
+        final indexAndMask iam = new indexAndMask(index);
+        if ((data[iam.index] & iam.mask) == 0) {
+            data[iam.index] |= iam.mask;
             bitCount++;
             return true;
         }
@@ -52,8 +64,9 @@ public final class BitArray {
     }
 
     public boolean clear(long index) {
-        if (get(index)) {
-            data[(int) (index >>> 6)] &= ~(1L << index);
+        final indexAndMask iam = new indexAndMask(index);
+        if ((data[iam.index] & iam.mask) != 0) {
+            data[iam.index] &= ~iam.mask;
             bitCount--;
             return true;
         }

--- a/src/main/java/com/github/jparkie/pdd/BitArray.java
+++ b/src/main/java/com/github/jparkie/pdd/BitArray.java
@@ -38,25 +38,17 @@ public final class BitArray {
         return (int) numWords;
     }
 
-    private final class indexAndMask {
-        public final int index;
-        public final long mask;
-
-        public indexAndMask(long index) {
-            this.index = (int)(index >>> 6);
-            this.mask = 1L << (index & 0x3F);
-        }
-    }
-
     public boolean get(long index) {
-        final indexAndMask iam = new indexAndMask(index);
-        return (data[iam.index] & iam.mask) != 0;
+        final int arrayIndex = (int)(index >>> 6);
+        final long bitMask = 1L << (index & 0x3F);
+        return (data[arrayIndex] & bitMask) != 0;
     }
 
     public boolean set(long index) {
-        final indexAndMask iam = new indexAndMask(index);
-        if ((data[iam.index] & iam.mask) == 0) {
-            data[iam.index] |= iam.mask;
+        final int arrayIndex = (int)(index >>> 6);
+        final long bitMask = 1L << (index & 0x3F);
+        if ((data[arrayIndex] & bitMask) == 0) {
+            data[arrayIndex] |= bitMask;
             bitCount++;
             return true;
         }
@@ -64,9 +56,10 @@ public final class BitArray {
     }
 
     public boolean clear(long index) {
-        final indexAndMask iam = new indexAndMask(index);
-        if ((data[iam.index] & iam.mask) != 0) {
-            data[iam.index] &= ~iam.mask;
+        final int arrayIndex = (int)(index >>> 6);
+        final long bitMask = 1L << (index & 0x3F);
+        if ((data[arrayIndex] & bitMask) != 0) {
+            data[arrayIndex] &= ~bitMask;
             bitCount--;
             return true;
         }


### PR DESCRIPTION
Centralize the calculation of the array index and mask into a helper class to ensure the calculations only get done once.